### PR TITLE
Allow user to set an output dir for artifacts.

### DIFF
--- a/matrix/main.py
+++ b/matrix/main.py
@@ -14,6 +14,12 @@ from . import utils
 
 def configLogging(options):
     logging.captureWarnings(True)
+    if options.output_dir:
+        # Set output dir for log.
+        config.LoggingConfig['handlers']['file']['filename'] = str(Path(
+            options.output_dir,
+            config.LoggingConfig['handlers']['file']['filename']))
+
     logging.config.dictConfig(config.LoggingConfig)
 
     root_logger = logging.getLogger()
@@ -83,9 +89,17 @@ def setup(matrix, args=None):
     parser.add_argument("-k", "--keep-models", action="store_true",
                         default=False, help="Keep the created per-test models "
                                             "for further inspection")
-    parser.add_argument("-l", "--log-level", default=None)
-    parser.add_argument("-L", "--log-name", nargs="*")
-    parser.add_argument("-f", "--log-filter", nargs="*")
+    parser.add_argument("-l", "--log-level", default=None,
+                        help="Set log level.")
+    parser.add_argument("-L", "--log-name", nargs="*",
+                        help="If specified, log-level param will only "
+                             "apply to the named internal log.")
+    parser.add_argument("-f", "--log-filter", nargs="*",
+                        help="Specify a custom log filter.")
+    parser.add_argument("-d", "--output-dir", default=None,
+                        help="Directory that should contain logs, "
+                             "glitch plans, and other artifacts. Defaults "
+                             "to the current working dir.")
     parser.add_argument("-s", "--skin", choices=("tui", "raw"), default="tui")
     parser.add_argument("-x", "--xunit", default=None, metavar='FILENAME',
                         help="Create an XUnit report file")

--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -381,7 +381,11 @@ class RuleEngine:
                 await self.run_once(context, test)
             finally:
                 try:
-                    await utils.crashdump(log=log)
+                    await utils.crashdump(
+                        log=log,
+                        tag=context.juju_model.info.name,
+                        directory=context.config.output_dir
+                    )
                 except Exception as e:
                     log.exception("Error while running crashdump.")
                 if not self.keep_models:

--- a/matrix/tasks/glitch/main.py
+++ b/matrix/tasks/glitch/main.py
@@ -87,8 +87,12 @@ async def glitch(context, rule, task, event=None):
             num=int(config.glitch_num))
         glitch_plan = validate_plan(glitch_plan)
 
-        rule.log.info("Writing glitch plan to {}".format(config.glitch_output))
-        with open(config.glitch_output, 'w') as output_file:
+        if config.output_dir:
+            glitch_output = Path(config.output_dir, config.glitch_output)
+        else:
+            glitch_output = Path(config.glitch_output)
+        rule.log.info("Writing glitch plan to {}".format(glitch_output))
+        with glitch_output.open('w') as output_file:
             output_file.write(yaml.dump(glitch_plan))
 
     # Execute glitch plan. We perform destructive operations here!


### PR DESCRIPTION
matrix.log, glitch_plan.yaml, and the crash dump now go in a specified
directory.

@johnsca 