### PR TITLE
Added basic functional testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ virtualenv:
     tox -r
     . .tox/py35/bin/activate
 
+### Functional testing
+
 Matrix also includes a full-stack test, which requires you to pass in a
 controller name to run:
 
@@ -85,6 +87,12 @@ controller name to run:
 
 Note that this takes some time, as it runs the default Matrix test suite
 against a trivial bundle.
+
+If you want to do more thorough functional testing of the various
+quirks and corners of matrix, you can run the functional testing suite
+via tox like so:
+
+    tox -r -e functional -v
 
 
 High level Design

--- a/matrix/utils.py
+++ b/matrix/utils.py
@@ -242,6 +242,8 @@ async def crashdump(log, tag, directory=None):
     # Wrap the logs and glitch plan (if any) up in a tarball.
     logfile = 'matrix.log'
     plan = 'glitch_plan.yaml'
+    if tag.startswith("matrix-"):
+        tag = tag[7:]  # Strip off extra "matrix"
     tarball = 'matrix_{}.tar.gz'.format(tag)
     if directory:
         tarball = str(Path(directory, tarball))

--- a/tests/functional/basic_test.py
+++ b/tests/functional/basic_test.py
@@ -1,0 +1,19 @@
+import subprocess
+from pathlib import Path
+
+from .harness import Harness
+
+
+class TestBasic(Harness):
+    '''
+    Verify that we can run the default matrix suite on the basic
+    bundle, in reasonable time.
+
+    '''
+    def setUp(self):
+        super(TestBasic, self).setUp()
+        self.artifacts = ['matrix.log', 'glitch_plan.yaml']
+
+    def test_basics(self):
+        subprocess.run(self.cmd, timeout=1000)
+        self.check_artifacts(4)  # 2 tarballs, log, and glitch plan

--- a/tests/functional/gating_test.py
+++ b/tests/functional/gating_test.py
@@ -1,0 +1,35 @@
+import subprocess
+from pathlib import Path
+
+from .harness import Harness
+
+
+class TestGating(Harness):
+    '''
+    Verify that we exit with an exit code other than 0 when
+    appropriate, based on TestFailures or uncaught Exceptions in
+    matrix.
+
+    '''
+    def setUp(self):
+        super(TestGating, self).setUp()
+        self.cmd.append("-D")  # Skip default tests
+        self.artifacts = ['matrix.log']  # No glitch plan
+
+    def test_gating_test_failure(self):
+        test = 'tests/test_gating.matrix'
+        proc = subprocess.run(self.cmd + [test], check=False, timeout=60)
+        self.assertEqual(proc.returncode, 1)
+        self.check_artifacts(2)  # Tarball and log
+
+    def test_gating_uncaught_exception(self):
+        test = 'tests/test_uncaught_exception.matrix'
+        proc = subprocess.run(self.cmd + [test], check=False, timeout=60)
+        self.assertEqual(proc.returncode, 1)
+        self.check_artifacts(2)  # Tarball and log
+
+    def test_turn_off_gating(self):
+        test = 'tests/test_non_gating.matrix'
+        proc = subprocess.run(self.cmd + [test], check=False, timeout=60)
+        self.assertEqual(proc.returncode, 0)
+        self.check_artifacts(2)  # Tarball and log

--- a/tests/functional/harness.py
+++ b/tests/functional/harness.py
@@ -1,0 +1,55 @@
+from logging import getLogger
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from unittest import TestCase
+
+
+class Harness(TestCase):
+    '''
+    Testing harness for our functional tests.
+
+    Provides a default command, which will, when passed to subprocess
+    unaltered, run the default matrix test on the basic bundle.
+
+    Also provides some facilities that a test can call to check up and
+    make sure that we create expected artifacts, like logs,
+    crashdumps, and glitch plans.
+
+    '''
+    def check_artifacts(self, num=None, crashdump=True):
+        '''
+        Verify that that artifacts that we expect to exist, do.
+
+        Optionally verify the number of artifacts created.
+
+        '''
+        artifacts = [Path(self.tmpdir, a) for a in self.artifacts]
+
+        if crashdump:
+            tarballs = Path(self.tmpdir).glob('matrix*tar.gz')
+            self.assertTrue(tarballs)
+            artifacts.extend(tarballs)
+
+        for a in artifacts:
+            self.assertTrue(a.exists())
+
+        if num is not None:
+            self.assertEqual(len(artifacts), num)
+
+    def setUp(self):
+        self.log = getLogger('functional_tests')
+
+        self.tmpdir = mkdtemp()
+        self.log.info("Outputting artifacts to {}".format(self.tmpdir))
+
+        self.cmd = [
+            'matrix',
+            '-s', 'raw',
+            '-p', 'tests/basic_bundle',
+            '-d', self.tmpdir
+        ]
+        self.artifacts = []
+
+    def tearDown(self):
+        rmtree(self.tmpdir)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skipsdist = True
 
 [testenv]
 install_command =  pip install {opts} {packages}
-commands = py.test --cov=matrix {posargs} -v
+commands = py.test --cov=matrix {posargs} -v --ignore=tests/functional
 passenv =
     HOME
 # --no-index below is needed to work around
@@ -20,3 +20,7 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
     -f{toxinidir}/wheelhouse
+
+[testenv:functional]
+basepython=python3
+commands = py.test {posargs} -v tests/functional


### PR DESCRIPTION
Independently runs multiple .matrix tests, and cleans up after itself.

Can be invoked with `tox -r -e functional -v`

Should save us some time and worry, going forward.

@johnsca This isn't bad for a time boxed pass at it. lmk if there's anything that especially stands out to you as needing work before we merge it.