### PR TITLE
Added support for MATRIX_OUTPUT_DIR env variable.

### DIFF
--- a/matrix/main.py
+++ b/matrix/main.py
@@ -4,6 +4,7 @@ import logging
 import logging.config
 from pathlib import Path
 from pkg_resources import resource_filename
+import os
 import sys
 
 from .bus import Bus, set_default_bus
@@ -96,7 +97,8 @@ def setup(matrix, args=None):
                              "apply to the named internal log.")
     parser.add_argument("-f", "--log-filter", nargs="*",
                         help="Specify a custom log filter.")
-    parser.add_argument("-d", "--output-dir", default=None,
+    parser.add_argument("-d", "--output-dir",
+                        default=os.getenv('MATRIX_OUTPUT_DIR'),
                         help="Directory that should contain logs, "
                              "glitch plans, and other artifacts. Defaults "
                              "to the current working dir.")

--- a/tests/functional/env_test.py
+++ b/tests/functional/env_test.py
@@ -1,0 +1,32 @@
+import subprocess
+from pathlib import Path
+import os
+
+from .harness import Harness
+
+
+class TestEnv(Harness):
+    '''
+    Verify that we can set config via env variables.
+
+    '''
+    def setUp(self):
+        super(TestEnv, self).setUp()
+
+        self.cmd = [
+            'matrix',
+            '-s', 'raw',
+            '-p', 'tests/basic_bundle',
+            '-D'
+        ]
+        os.environ['MATRIX_OUTPUT_DIR'] = self.tmpdir
+        self.artifacts = ['matrix.log']
+
+    def tearDown(self):
+        os.unsetenv('MATRIX_OUTPUT_DIR')
+
+    def test_set_env(self):
+        test = 'tests/test_non_gating.matrix'  # Lightweight test
+        proc = subprocess.run(self.cmd + [test], check=False, timeout=60)
+        self.assertEqual(proc.returncode, 0)
+        self.check_artifacts(2)  # Tarball and log


### PR DESCRIPTION
Helps us in cloud weather report, where we want to pass the value
through multiple subprocess calls.

@johnsca (This will soon be accompanied by a matching PR in layer-cwr)