### PR TITLE
Feature/skip crashdump if no failure

### DIFF
--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -413,11 +413,12 @@ class RuleEngine:
         context.states.clear()
         context.waiters.clear()
         try:
-            await utils.crashdump(
-                log=log,
-                model_name=context.juju_model.info.name,
-                directory=context.config.output_dir
-            )
+            if self.exit_code:
+                await utils.crashdump(
+                    log=log,
+                    model_name=context.juju_model.info.name,
+                    directory=context.config.output_dir
+                )
         except Exception as e:
             log.exception("Error while running crashdump.")
         if not self.keep_models:

--- a/matrix/utils.py
+++ b/matrix/utils.py
@@ -226,7 +226,7 @@ async def crashdump(log, model_name, directory=None):
 
     '''
     log.info("Running crash dump")
-    cmd = ['juju-crashdump', '-m', model_name, '-u', model_name]
+    cmd = ['juju-crashdump', '-m', model_name, '-u', model_name, '-s']
     if directory:
         cmd += ['-o', directory]
     try:


### PR DESCRIPTION
Only run crashdump if there has been a test failure.

Also snuck in "-s" flag.

@johnsca @kwmonroe @ktsakalozos 