### PR TITLE
Gracefully handle "virtualenv ."

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skipsdist = True
 
 [testenv]
 install_command =  pip install {opts} {packages}
-commands = py.test --cov=matrix {posargs} -v --ignore=tests/functional
+commands = py.test --cov=matrix {posargs} -v --ignore=tests/functional --ignore=lib --ignore=bin --ignore=local
 passenv =
     HOME
 # --no-index below is needed to work around


### PR DESCRIPTION
If the current directory is turned into a virtualenv, it will cause tox failures.  We don't recommend this, but we can handle it gracefully.