### PR TITLE
Fix error in cleanup if model creation fails

### DIFF
--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -413,10 +413,16 @@ class RuleEngine:
         context.states.clear()
         context.waiters.clear()
         try:
-            if self.exit_code:
+            if self.model:
+                model_name = self.model
+            elif context.juju_model:
+                model_name = context.juju_mode.info.name
+            else:
+                model_name = None
+            if self.exit_code and model_name:
                 await utils.crashdump(
                     log=log,
-                    model_name=context.juju_model.info.name,
+                    model_name=model_name,
                     directory=context.config.output_dir
                 )
         except Exception as e:


### PR DESCRIPTION
Fixes this:

```
packages/matrix/matrix.yaml
matrix:378:run: Error adding model: 'Controller' object has no attribute 'get_cloud'
------------------------------------------------------------------------------
matrix:423:cleanup: Error while running crashdump.
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/matrix/rules.py", line 419, in cleanup
    model_name=context.juju_model.info.name,
AttributeError: 'Attribute' object has no attribute 'info'
```

The distill cause, of course, is that it had an outdated version of libjuju.  However, it should handle the uncreated model gracefully regardless.