### PR TITLE
Extract perform action

### DIFF
--- a/matrix/tasks/glitch/main.py
+++ b/matrix/tasks/glitch/main.py
@@ -52,6 +52,57 @@ async def select(rule, model, selectors, objects=None,
     return cur
 
 
+async def execute_actions(actions, model, rule, exception, bus=None):
+    """Execute a glitch plan.
+
+    :param actions: A list of actions from a glitch plan.
+    :param model: A Juju model to apply the actions to.
+    :param rule: A model.Rule, typically used for logging.  Passed on to
+        Glitch actions.
+    :param exception: The exception to raise if errors are encountered.  If
+        None, no exception will be raised if errors are encountered.
+    :param bus: Bus to send glitch.activate events to.  If None, no events
+        will be sent.
+    """
+    # Execute glitch plan. We perform destructive operations here!
+    for action in actions:
+        actionf = Actions[action.pop('action')]['func']
+        selectors = action.pop('selectors')
+        # Find a set of units to act upon
+        objects = await select(rule, model, selectors)
+        if not objects:
+            # If we get an empty set of objects back, just skip this action.
+            rule.log.error(
+                "Could not run {}. No objects for selectors {}".format(
+                    actionf.__name__, selectors))
+            continue
+
+        # Run the specified action on those units
+        rule.log.info("GLITCHING {}: {}".format(actionf.__name__, objects))
+
+        errors = False
+        try:
+            await asyncio.wait_for(actionf(rule, model, objects, **action), 30)
+        except asyncio.TimeoutError:
+            rule.log.error("Timeout running {}".format(actionf.__name__))
+            errors = True
+        except Exception as e:
+            rule.log.exception(
+                "Exception while running {}: {} {}.".format(
+                    actionf.__name__, type(e), e))
+            errors = True
+        if errors and exception is not None:
+            raise exception
+
+        if bus is not None:
+            bus.dispatch(
+                origin="glitch",
+                payload={'action': actionf.__name__, **action},
+                kind="glitch.activate"
+            )
+        await asyncio.sleep(2, loop=model.loop)
+
+
 async def glitch(context, rule, task, event=None):
     """
     Perform a set of actions against a model, with a mind toward causing
@@ -98,44 +149,12 @@ async def glitch(context, rule, task, event=None):
         with glitch_output.open('w') as output_file:
             output_file.write(yaml.dump(glitch_plan))
 
-    # Execute glitch plan. We perform destructive operations here!
-    for action in glitch_plan['actions']:
-        actionf = Actions[action.pop('action')]['func']
-        selectors = action.pop('selectors')
-        # Find a set of units to act upon
-        objects = await select(rule, model, selectors)
-        if not objects:
-            # If we get an empty set of objects back, just skip this action.
-            rule.log.error(
-                "Could not run {}. No objects for selectors {}".format(
-                    actionf.__name__, selectors))
-            continue
-
-        # Run the specified action on those units
-        rule.log.info("GLITCHING {}: {}".format(actionf.__name__, objects))
-
-        errors = False
-        try:
-            await asyncio.wait_for(actionf(rule, model, objects, **action), 30)
-        except asyncio.TimeoutError:
-            rule.log.error("Timeout running {}".format(actionf.__name__))
-            errors = True
-        except Exception as e:
-            rule.log.exception(
-                "Exception while running {}: {} {}.".format(
-                    actionf.__name__, type(e), e))
-            errors = True
-        if errors and task.gating:
-            raise TestFailure(
-                task, "Exceptions were raised during glitch run.")
-
-        context.bus.dispatch(
-            origin="glitch",
-            payload={'action': actionf.__name__, **action},
-            kind="glitch.activate"
-        )
-        await asyncio.sleep(2, loop=context.loop)
-
+    if task.gating:
+        exception = TestFailure(
+                    task, "Exceptions were raised during glitch run.")
+    else:
+        exception = None
+    await execute_actions(glitch_plan['actions'], model, rule, exception,
+                          context.bus)
     rule.log.info("Finished glitch")
-
     return True

--- a/tests/glitch/test_main.py
+++ b/tests/glitch/test_main.py
@@ -5,7 +5,6 @@ import unittest
 from unittest.mock import patch
 import yaml
 
-from juju.application import Application
 from juju.model import Model
 from juju.delta import ApplicationDelta, UnitDelta
 
@@ -52,39 +51,42 @@ class TestPerformAction(unittest.TestCase):
 
     def test_perform_action_happy_path(self):
         juju_model = make_test_model()
-        self.assertEqual(('kill_juju_agent', False),
-            self.loop.run_until_complete(perform_action(
-                                         kill_juju_agent(), juju_model,
-                                         self.rule)))
+        self.assertEqual(
+            ('kill_juju_agent', False),
+            self.loop.run_until_complete(
+                perform_action(kill_juju_agent(), juju_model, self.rule)))
 
     def test_perform_action_no_objects(self):
         juju_model = make_test_model(foo_unit=False)
-        with self.assertRaisesRegex(NoObjects,
+        with self.assertRaisesRegex(
+                NoObjects,
                 r"Could not run kill_juju_agent. No objects for selectors"):
-            self.loop.run_until_complete(perform_action(kill_juju_agent(),
-                                                        juju_model, self.rule))
+            self.loop.run_until_complete(perform_action(
+                kill_juju_agent(), juju_model, self.rule))
 
     def test_perform_action_error(self):
         juju_model = make_test_model()
         async def kill_raise(a, b, c):
             raise Exception
-        with patch.dict(actions.Actions, {'kill_juju_agent': {'func':
-            kill_raise}}):
-            self.assertEqual(('kill_raise', True),
-                self.loop.run_until_complete(perform_action(
-                                             kill_juju_agent(), juju_model,
-                                             self.rule)))
+        with patch.dict(actions.Actions, {'kill_juju_agent': {
+                'func': kill_raise,
+                }}):
+            self.assertEqual(
+                ('kill_raise', True),
+                self.loop.run_until_complete(
+                    perform_action(kill_juju_agent(), juju_model, self.rule)))
 
     def test_perform_action_timeout_error(self):
         juju_model = make_test_model()
         async def kill_raise(a, b, c):
             raise asyncio.TimeoutError()
-        with patch.dict(actions.Actions, {'kill_juju_agent': {'func':
-            kill_raise}}):
-            self.assertEqual(('kill_raise', True),
-                self.loop.run_until_complete(perform_action(
-                                             kill_juju_agent(), juju_model,
-                                             self.rule)))
+        with patch.dict(actions.Actions, {'kill_juju_agent': {
+                'func': kill_raise,
+                }}):
+            self.assertEqual(
+                ('kill_raise', True),
+                self.loop.run_until_complete(
+                    perform_action(kill_juju_agent(), juju_model, self.rule)))
 
 
 class TestGlitch(unittest.TestCase):

--- a/tests/glitch/test_main.py
+++ b/tests/glitch/test_main.py
@@ -1,0 +1,54 @@
+import asyncio
+from tempfile import NamedTemporaryFile
+import unittest
+import yaml
+
+from juju.application import Application
+from juju.model import Model
+from juju.delta import ApplicationDelta, UnitDelta
+
+from matrix import model
+from matrix.bus import Bus
+from matrix.tasks.glitch.main import glitch
+
+
+class TestGlitch(unittest.TestCase):
+
+    def test_glitch(self):
+        task = model.Task(command='glitch', args={'path': None})
+        rule = model.Rule(task)
+        loop = asyncio.get_event_loop()
+        bus = Bus(loop=loop)
+        suite = []
+
+        class config:
+            path = None
+
+        context = model.Context(loop, bus, suite, config, None)
+
+        juju_model = Model()
+        juju_model.state.apply_delta(ApplicationDelta(
+            ('application', 'type2', {'name': 'foo'})))
+        juju_model.state.apply_delta(UnitDelta(('unit', 'type1', {
+            'name': 'steve',
+            'application': 'foo',
+            })))
+
+        context.juju_model = juju_model
+
+        plan = {'actions': [{
+            'action': 'kill_juju_agent',
+            'selectors': [{
+                'selector': 'units',
+                'application': 'foo',
+                }],
+            }]}
+
+        with NamedTemporaryFile() as plan_file:
+            yaml.safe_dump(plan, plan_file, encoding='utf8')
+            task.args['plan'] = plan_file.name
+            loop.run_until_complete(glitch(context, rule, task, None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This branch extracts perform_action from main.glitch().

For Hammer Time, Task, Rule, Bus, Context all don't seem necessary.  I have been able to execute a plan using main.glitch(), but it requires more set-up than seems appropriate.  By extracting perform_action, glitch plans become much easier to use.

In order to do this refactoring, I added unit tests for main.glitch() and perform_action.

It passes tox -r.  I didn't see a preferred linter, so I used flake8.