### PR TITLE
Added timeout to matrix tests.

### DIFF
--- a/matrix/main.py
+++ b/matrix/main.py
@@ -13,6 +13,10 @@ from . import rules
 from . import utils
 
 
+RAW_TIMEOUT = 3600
+TUI_TIMEOUT = None
+
+
 def configLogging(options):
     logging.captureWarnings(True)
     if options.output_dir:
@@ -127,7 +131,22 @@ def setup(matrix, args=None):
     parser.add_argument("-n", "--glitch_num", default=5)
     parser.add_argument("-o", "--glitch_output",
                         default="glitch_plan_{model_name}.yaml")
+    parser.add_argument("-z", "--timeout", type=int,
+                        help=("Max seconds for a test to run. "
+                              "Defaults to {} for raw (non interactive) mode; "
+                              "defaults to {} for tui (interactive) "
+                              "mode.".format(
+                                  RAW_TIMEOUT,
+                                  TUI_TIMEOUT or "no timeout"
+                              )
+                        ))
     options = parser.parse_args(args, namespace=matrix)
+    # Set default timeouts
+    if options.timeout is None:
+        if options.skin == 'raw':
+            options.timeout = RAW_TIMEOUT
+        if options.skin == 'tui':
+            options.timeout = TUI_TIMEOUT  # None
     if not (options.path.is_dir() and (options.path / 'bundle.yaml').exists()):
         parser.error('Invalid bundle directory: %s' % options.path)
 

--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -311,13 +311,15 @@ class RuleEngine:
         # rule_runner will run each rule to completion
         # (either success or failure) and then terminate here
         done, pending = await asyncio.wait(
-                self.jobs, loop=self.loop,
-                return_when=asyncio.FIRST_EXCEPTION)
+            self.jobs, loop=self.loop,
+            return_when=asyncio.FIRST_EXCEPTION,
+            timeout=context.config.timeout)
         if pending:
             # We terminated with things still running
             # this could be a test failure or poor rule formation.
             # can we do anything here
-            log.warn("Pending tasks remain, aborting due to failure")
+            log.warn(
+                "Pending tasks remain, aborting due to failure or timeout")
 
         exceptions = [(t, t.exception()) for t in done if t.exception()]
         if exceptions:


### PR DESCRIPTION
Defaults to one hour for non interactive mode, and no timeout for
interactive mode. Controllable with a command line param, as it applies
to an entire test suite.

Should prevent matrix from outlasting the energizer bunny.

@johnsca @kwmonroe @ktsakalozos 