### PR TITLE
Remove special case for localhost provider in credentials logic

### DIFF
--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -476,8 +476,6 @@ class RuleEngine:
         This is a work-around for https://bugs.launchpad.net/juju/+bug/1652171
         """
         cloud = await context.juju_controller.get_cloud()
-        if cloud in ('localhost', 'lxd'):
-            return None
         creds_file = Path('~/.local/share/juju/credentials.yaml').expanduser()
         if creds_file.exists():
             creds = yaml.safe_load(creds_file.read_text())['credentials']


### PR DESCRIPTION
The localhost provider not requiring credentials in 2.0 was "working by accident."  2.1 closed that gap and now we always require credentials.

Fixes #93