### PR TITLE
Fix "loop closed" error when running full stack test

### DIFF
--- a/matrix/utils.py
+++ b/matrix/utils.py
@@ -5,7 +5,7 @@ import logging
 import importlib
 import re
 import textwrap
-from pathlib import Path
+from contextlib import contextmanager
 
 import urwid
 
@@ -235,7 +235,18 @@ async def crashdump(log, model_name, directory=None):
             log.info("Crashdump COMPLETE")
         else:
             log.error("Crashdump FAILED")
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         log.warning(
             "Tried to run crashdump, but could not find the executable. "
             "Is it installed in your environment?")
+
+
+@contextmanager
+def new_event_loop():
+    old_loop = asyncio.get_event_loop()
+    new_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(new_loop)
+    try:
+        yield new_loop
+    finally:
+        asyncio.set_event_loop(old_loop)

--- a/tests/test_full_stack.py
+++ b/tests/test_full_stack.py
@@ -3,6 +3,7 @@ import pytest
 import unittest
 
 from matrix.main import main
+from matrix.utils import new_event_loop
 
 
 class TestFullStack(unittest.TestCase):
@@ -10,5 +11,6 @@ class TestFullStack(unittest.TestCase):
         controller = pytest.config.getoption('--controller')
         if not controller:
             raise unittest.SkipTest()
-        bundle = Path(__file__).parent / 'basic_bundle'
-        main(['-c', controller, '-p', str(bundle), '-s', 'raw'])
+        with new_event_loop():
+            bundle = Path(__file__).parent / 'basic_bundle'
+            main(['-c', controller, '-p', str(bundle), '-s', 'raw'])


### PR DESCRIPTION
The full stack test closes the event loop, which conflicts with some of the other tests that use the default loop.