### PR TITLE
Tweaks for versioning and packaging.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-*This is Alpha software. It isn't feature complete yet.*
-
-
 Matrix
 ======
 
@@ -73,27 +70,27 @@ and the YAML could refer to them via `tests.matrix.task_name`.
 Running Matrix
 --------------
 
-Install and run Matrix by doing the following:
+Install and run Matrix as a juju plugin by doing the following:
 
     git clone https://github.com/juju-solutions/matrix.git
     cd matrix
     sudo pip3 install . -f wheelhouse --no-index
-    matrix -p /path/to/bundle
+    juju matrix -p /path/to/bundle
 
 This will run Matrix in interactive mode, with a terminal UI that shows
 the progress of each test, their results, the status of the Juju model,
 and the Juju debug log.  If you prefer to use the non-interactive mode,
 invoke Matrix with the `raw` screen option:
 
-    matrix -p /path/to/bundle -s raw
+    juju matrix -p /path/to/bundle -s raw
 
 By default, Matrix runs its built-in suite of tests, along with a `matrix.yaml`
 test case if found in the bundle.  You can also pass in additional Matrix
 tests via the command line:
 
-    matrix -p /path/to/bundle /path/to/other/test.yaml
+    juju matrix -p /path/to/bundle /path/to/other/test.yaml
 
-See `matrix --help` for more information and invocation options.
+See `juju matrix --help` for more information and invocation options.
 
 ### Running against bundles from the store
 
@@ -119,7 +116,7 @@ from which you can run Matrix:
     cd matrix/
     tox -r
     . .tox/py35/bin/activate
-    matrix -p /path/to/bundle
+    juju matrix -p /path/to/bundle
 
 Note that if any of the requirements change, you will need to rebuild the
 virtualenv:

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ with open(reqs_file) as f:
             if not line.startswith('--')]
 
 SETUP = {
-    'name': "matrix",
+    'name': "jujumatrix",
     'packages': find_packages(),
-    'version': "0.5.3",
+    'version': "0.9.0",
     'author': "Juju Developers",
     'author_email': "juju@lists.ubuntu.com",
     'url': "https://github.com/juju-solutions/matrix",
@@ -18,7 +18,8 @@ SETUP = {
     'long_description': open('README.md').read(),
     'entry_points': {
         'console_scripts': [
-            'matrix = matrix.main:main',
+            # Script can be invoked as a matrix plugin: `juju matrix`
+            'juju-matrix = matrix.main:main',
         ]
     },
     'install_requires': reqs,

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ SETUP = {
         'console_scripts': [
             # Script can be invoked as a matrix plugin: `juju matrix`
             'juju-matrix = matrix.main:main',
+            # The following script is deprecated:
+            'matrix = matrix.main:main',
         ]
     },
     'install_requires': reqs,


### PR DESCRIPTION
`python setup.py sdist` now produces a tarball that works with pip
install. (More ways to install!)

Updated version (we haven't done so in a while).

Got rid of "this is an alpha!" scare text. We're now in beta :-)

Changed executable to `juju-matrix`, to be consistent with plans for the
snap. This has the added benefit of making matrix work as a juju
"plugin" -- i.e., it can be run as `juju matrix`.

Changed name of package in setup.py to jujumatrix, to reflect our plans
for posting to pypi without conflicting with the existing "matrix" package.

@tvansteenburgh @johnsca @abentley @kwmonroe @seman @ludostag