### PR TITLE
Fixed info spam on model deploy failure.

### DIFF
--- a/matrix/model.py
+++ b/matrix/model.py
@@ -66,7 +66,7 @@ class Context:
     # XXX: use an event for this?
     waiters = attr.ib(default=attr.Factory(dict), repr=False, init=False)
     juju_controller = attr.ib(repr=False)
-    juju_model = attr.ib(repr=False, init=False)
+    juju_model = attr.ib(repr=False, init=False, default=None)
     test = attr.ib(repr=False, init=False)
 
     def set_state(self, name, value):


### PR DESCRIPTION
Added a default=None for juju_model, which allows the check for
"juju_model=None" to succeed in the teardown. This prevents the case
where you get a lot of "Attribute has no attribute info" spam in the
logs when attempting to cleanup a test where the model failed to deploy.

@johnsca @abentley @seman 