### PR TITLE
Removed SUBORDINATE_OK flag from reboot and kill_juju_agent

### DIFF
--- a/matrix/tasks/chaos/actions.py
+++ b/matrix/tasks/chaos/actions.py
@@ -13,7 +13,7 @@ from matrix.model import Rule
 
 from matrix.utils import Singleton
 
-from .tags import SUBORDINATE_OK
+from .tags import SUBORDINATE_OK  # noqa
 
 log = logging.getLogger("chaos")
 
@@ -72,7 +72,7 @@ action = Actions.decorate
 #
 # Define your actions here
 #
-@action(SUBORDINATE_OK)
+@action
 async def reboot(rule: Rule, model: Model, unit: Unit):
     """
     Given a set of units, send a reboot command to all of them.
@@ -122,7 +122,7 @@ async def add_unit(rule: Rule, model: Model, application: Application,
     await application.add_unit(count=count, to=to)
 
 
-@action(SUBORDINATE_OK)
+@action
 async def kill_juju_agent(rule: Rule, model: Model, unit: Unit):
     """Kill the juju agent on a machine."""
 

--- a/tests/chaos.matrix
+++ b/tests/chaos.matrix
@@ -1,0 +1,17 @@
+#!/usr/bin/env matrix
+"tests":
+- "name": just_chaos
+  "description": Deploy, then cause chaos
+  "rules":
+    - "do":
+        "task": matrix.tasks.deploy
+    - "after": deploy
+      "periodic": 5
+      "do":
+        "task": matrix.tasks.health
+      "gating": ha_only
+      "until": chaos.complete
+    - "after": health.status.healthy
+      "do":
+        "task": matrix.tasks.chaos
+      "gating": ha_only


### PR DESCRIPTION
It's not really necessary to automatically generate reboot and kill_juju_agent actions for
subordinate charms. There's always a parent charm that we can run those
actions against, instead.

Leaving the SUBORDINATE_OK flag in the codebase for now, just in case we
do add an action that needs it.

@johnsca @seman @abentley 