### PR TITLE
Remove internal Timeout for matrix tests.

### DIFF
--- a/matrix/main.py
+++ b/matrix/main.py
@@ -14,10 +14,6 @@ from . import rules
 from . import utils
 
 
-RAW_TIMEOUT = 3600
-TUI_TIMEOUT = None
-
-
 def configLogging(options):
     logging.captureWarnings(True)
     if options.output_dir:
@@ -169,13 +165,6 @@ def setup(matrix, args=None):
     parser.add_argument("-n", "--chaos_num", default=5)
     parser.add_argument("-o", "--chaos_output",
                         default="chaos_plan_{model_name}.yaml")
-    parser.add_argument("-z", "--timeout", type=int,
-                        help=("Max seconds for a test to run. "
-                              "Defaults to {} for raw (non interactive) mode; "
-                              "defaults to {} for tui (interactive) "
-                              "mode.".format(
-                                  RAW_TIMEOUT,
-                                  TUI_TIMEOUT or "no timeout")))
     parser.add_argument("-H", "--ha", action='store_true',
                         help=("Treat this bundle as a 'high availabilty' "
                               "bundle. This means that tests that gate on "
@@ -186,13 +175,6 @@ def setup(matrix, args=None):
 
     if not utils.valid_bundle_or_spell(options.path):
         parser.error('Invalid bundle directory: %s' % options.path)
-
-    # Set default timeouts
-    if options.timeout is None:
-        if options.skin == 'raw':
-            options.timeout = RAW_TIMEOUT
-        if options.skin == 'tui':
-            options.timeout = TUI_TIMEOUT  # None
 
     configLogging(options)
     return options

--- a/matrix/rules.py
+++ b/matrix/rules.py
@@ -313,14 +313,13 @@ class RuleEngine:
         # (either success or failure) and then terminate here
         done, pending = await asyncio.wait(
             self.jobs, loop=self.loop,
-            return_when=asyncio.FIRST_EXCEPTION,
-            timeout=context.config.timeout)
+            return_when=asyncio.FIRST_EXCEPTION)
         if pending:
             # We terminated with things still running
             # this could be a test failure or poor rule formation.
             # can we do anything here
             log.warn(
-                "Pending tasks remain, aborting due to failure or timeout")
+                "Pending tasks remain, aborting due to failure.")
 
         exceptions = [(t, t.exception()) for t in done if t.exception()]
         if exceptions:


### PR DESCRIPTION
This is an Alexandrian solution to our "matrix is too green" bug.
(https://github.com/juju-solutions/matrix/issues/123)

It also makes things a lot nicer in general. External tools calling
matrix still have to include a timeout, because the existing matrix
timeout only covered hangs during a test run; hangs during setup
or teardown could still lead to a hung matrix. And External tools with
a timeout still have to worry about cleaning up matrix models; having an
internal timeout cleanup that only helps in some cases isn't necessary.

This also simplifies the code, and removes a command line param. A win
all around, I think.

@johnsca @kwmonroe 